### PR TITLE
Remove community.docker role

### DIFF
--- a/requirements.yml
+++ b/requirements.yml
@@ -2,8 +2,6 @@
 collections:
   - name: chocolatey.chocolatey
     version: 1.3.1
-  - name: community.docker
-    version: 3.2.2
   - name: community.general
     version: 6.0.1
 


### PR DESCRIPTION
This role was previously needed for the molecule-docker package, but in version 2.1.0 this dependency was fixed, so we shouldn't need to add this collection to our requirements.yml file anymore.