### PR TITLE
Update ableton-utils to 0.24.x

### DIFF
--- a/Jenkinsfile
+++ b/Jenkinsfile
@@ -1,4 +1,4 @@
-library(identifier: 'ableton-utils@0.23', changelog: false)
+library(identifier: 'ableton-utils@0.24', changelog: false)
 library(identifier: 'groovylint@0.13', changelog: false)
 library(identifier: 'python-utils@0.13', changelog: false)
 

--- a/molecule/bionic-binary/converge.yml
+++ b/molecule/bionic-binary/converge.yml
@@ -9,4 +9,4 @@
     node_exporter_port: 9999
     node_exporter_version: "1.4.0"
   roles:
-    - ansible-role-prometheus-node-exporter
+    - ableton.prometheus_node_exporter

--- a/molecule/bionic-package/converge.yml
+++ b/molecule/bionic-package/converge.yml
@@ -7,4 +7,4 @@
       - "--collector.cpu"
     node_exporter_port: 9999
   roles:
-    - ansible-role-prometheus-node-exporter
+    - ableton.prometheus_node_exporter

--- a/molecule/focal-binary/converge.yml
+++ b/molecule/focal-binary/converge.yml
@@ -9,4 +9,4 @@
     node_exporter_port: 9999
     node_exporter_version: "1.4.0"
   roles:
-    - ansible-role-prometheus-node-exporter
+    - ableton.prometheus_node_exporter

--- a/molecule/focal-package/converge.yml
+++ b/molecule/focal-package/converge.yml
@@ -7,4 +7,4 @@
       - "--collector.cpu"
     node_exporter_port: 9999
   roles:
-    - ansible-role-prometheus-node-exporter
+    - ableton.prometheus_node_exporter


### PR DESCRIPTION
This update contains some improvements with how Ansible roles are tested with Molecule that will allow us to remove some of our hacks regarding role naming in the Molecule configuration files.