### PR TITLE
Fix typo in role metadata description

### DIFF
--- a/meta/main.yml
+++ b/meta/main.yml
@@ -2,7 +2,7 @@
 galaxy_info:
   author: ableton
   company: Ableton AG
-  description: Installs the Promotheus node exporter service
+  description: Installs the Prometheus node exporter service
   license: MIT
   min_ansible_version: "2.10"
   role_name: prometheus_node_exporter


### PR DESCRIPTION
I noticed this when browsing our roles on Ansible Galaxy, since it uses the `meta.yml` files to build role information. 

![Screenshot from 2024-01-03 16-32-28](https://github.com/Ableton/ansible-role-prometheus-node-exporter/assets/16208985/61db2c7f-8ed4-49f9-b85f-9a4dcf73b5da)

:see_no_evil: :see_no_evil: :see_no_evil: 