### PR TITLE
Update groovylint to 0.18

### DIFF
--- a/Jenkinsfile
+++ b/Jenkinsfile
@@ -1,5 +1,5 @@
 library(identifier: 'ableton-utils@0.29', changelog: false)
-library(identifier: 'groovylint@0.16', changelog: false)
+library(identifier: 'groovylint@0.18', changelog: false)
 library(identifier: 'python-utils@0.15', changelog: false)
 
 


### PR DESCRIPTION
This PR updates the groovylint library to 0.18.x